### PR TITLE
fixes your economy :3 

### DIFF
--- a/main.py
+++ b/main.py
@@ -2333,7 +2333,7 @@ async def cat_fact(message: discord.Interaction):
 
 async def light_market(message):
     cataine_prices = [[10, "Fine"], [30, "Fine"], [20, "Good"], [15, "Rare"], [20, "Wild"], [10, "Epic"], [20, "Sus"], [15, "Rickroll"],
-                      [7, "Superior"], [5, "Legendary"], [3, "8bit"], [4, "Professor"], [3, "Real"], [2, "Ultimate"], [1, "eGirl"]]
+                      [7, "Superior"], [5, "Legendary"], [3, "8bit"], [4, "Divine"], [3, "Real"], [2, "Ultimate"], [1, "eGirl"]]
     user = get_profile(message.guild.id, message.user.id)
     if user.cataine_active < int(time.time()):
         count = user.cataine_week
@@ -2398,7 +2398,7 @@ async def light_market(message):
 
 async def dark_market(message):
     cataine_prices = [[10, "Fine"], [30, "Fine"], [20, "Good"], [15, "Rare"], [20, "Wild"], [10, "Epic"], [20, "Sus"], [15, "Rickroll"],
-                      [7, "Superior"], [5, "Legendary"], [3, "8bit"], [4, "Professor"], [3, "Real"], [2, "Ultimate"], [1, "eGirl"], [100, "eGirl"]]
+                      [7, "Superior"], [5, "Legendary"], [3, "8bit"], [4, "Divine"], [3, "Real"], [2, "Ultimate"], [1, "eGirl"], [100, "eGirl"]]
     user = get_profile(message.guild.id, message.user.id)
     if user.cataine_active < int(time.time()):
         level = user.dark_market_level


### PR DESCRIPTION
Proposed change: Change Cataine Price #12 from 4 Professor cats to 4 Divine cats
Reasoning: Currently, there is a huge mismatch in what one might expect to be the rarity of cats. A "Divine" cat would be expected to be rare and elusive. A Professor cat, while rare, should not be nearly on the same level as a Divine cat, let alone rarer. However, due to the situation created by Divine cats being a voting reward and Professor cats being a major roadblock in the way of progression in cataine, Professor cats are rarer. Not just slightly rarer, either- my model suggests that Professor cats in an optimal economy should be 3x rarer than Divine cats. In a less optimal economy like that of Cat Stand (or any server, I suppose) this difference is further exaggerated by a factor difficult to measure, but as seen by a trade between players "sack.ofcats" and "sillysnake2.0", 6 Divine cats were traded for 1 Professor cat. While this trade in particular may be seen as a move of desperation, it certainly reflects the attitude most people have towards Divine and Professor cats. By replacing the 4 Professor price of cataine with 4 Divine cats, this would be easily fixed. Professors would no longer be direly required, the roadblock represented by that price would be smoothed out significantly, and some of the unusual commonality of Divine cats would be removed. This alone will not make Professor cats more common than Divine cats- my math still suggests that Professor cats will be 50% more valuable. However, this is progress. To make Divine cats rarer than Professor cats, I suppose you could either remove them as a voting reward, add Professor cats as a voting reward, or change the price of this cataine to 8 Divine (although that would be a rather absurd price, to be fair.) I do hope that you accept this suggestion. Thank you for your time.