### PR TITLE
bot verification check for msg2img

### DIFF
--- a/msg2img.py
+++ b/msg2img.py
@@ -169,18 +169,23 @@ def msg2img(message):
 
     pencil.text((122, 8), nick, font=font, fill=color)  # draw author name
     if is_bot:
+        is_verified = message.author.public_flags.verified_bot
+    
         botfont = ImageFont.truetype(os.path.abspath("./fonts/whitneysemibold.otf"), 20)
 
         pencil.rounded_rectangle(
             (
                 129 + getsize(font, nick)[0] + 5,
                 8 + 5,
-                129 + getsize(font, nick)[0] + 14 + getsize(botfont, "APP")[0],
+                129 + getsize(font, nick)[0] + 14 + 24 * is_verified + getsize(botfont, "APP")[0],
                 10 + 6 + 25,
             ),
             fill=(88, 101, 242),
             radius=3,
         )
+        
+        if is_verified:
+            pass # idk how to use PIL but uh insert the image here
 
         pencil.text(
             (131 + getsize(font, nick)[0] + 8, 10 + 4),


### PR DESCRIPTION
adds verification checkmark if bot is verified

this is very much incomplete
idk how to use PIL
the svg path is `M19.06 6.94a1.5 1.5 0 0 1 0 2.12l-8 8a1.5 1.5 0 0 1-2.12 0l-4-4a1.5 1.5 0 0 1 2.12-2.12L10 13.88l6.94-6.94a1.5 1.5 0 0 1 2.12 0Z`
the actual svg is below
![svg-path](https://github.com/user-attachments/assets/f1e223be-0c22-4454-b7ad-c9fdef38a371)
