### PR TITLE
Reduce Battlepass chatter/noise

### DIFF
--- a/main.py
+++ b/main.py
@@ -558,7 +558,7 @@ async def progress_embed(message, user, level_data, current_xp, old_xp, quest_da
         color=0x007F0E
     ).set_author(name=level_text).set_footer(text="/battlepass")
 
-    return await message.channel.send(embed=embed)
+    return await message.channel.send(embed=embed, ephemeral=True)
 
 
 # handle curious people clicking buttons

--- a/main.py
+++ b/main.py
@@ -2363,16 +2363,14 @@ async def battlepass(message: discord.Interaction):
 
     async def toggle_reminders(interaction: discord.Interaction):
         nonlocal current_mode
-        if interaction.user.id != message.user.id:
-            await do_funny(interaction)
-            return
-        await interaction.response.defer()
+
+        await interaction.response.defer(ephemeral=True)
         user = get_profile(message.guild.id, message.user.id)
         if not user.reminders_enabled:
             try:
                 await interaction.user.send(f"You have enabled reminders in {interaction.guild.name}. You can disable them in the /battlepass command in that server or by saying `disable {interaction.guild.id}` here any time.")
             except Exception:
-                await interaction.followup.send("Failed. Ensure you have DMs open by going to Server > Privacy Settings > Allow direct messages from server members.")
+                await interaction.followup.send("Failed. Ensure you have DMs open by going to Server > Privacy Settings > Allow direct messages from server members.", ephemeral=True)
                 return
 
         user.reminders_enabled = not user.reminders_enabled
@@ -2399,10 +2397,8 @@ async def battlepass(message: discord.Interaction):
 
     async def gen_main(interaction, first=False):
         nonlocal current_mode
-        if interaction.user.id != message.user.id:
-            await do_funny(interaction)
-            return
-        await interaction.response.defer()
+        
+        await interaction.response.defer(ephemeral=True)
         current_mode = "Main"
         user = get_profile(message.guild.id, message.user.id)
         refresh_quests(user)
@@ -2497,16 +2493,14 @@ async def battlepass(message: discord.Interaction):
             embedVar.set_author(name="You have unread news! /news")
 
         if first:
-            await interaction.followup.send(embed=embedVar, view=view)
+            await interaction.followup.send(embed=embedVar, view=view, ephemeral=True)
         else:
             await interaction.edit_original_response(embed=embedVar, view=view)
 
     async def gen_rewards(interaction):
         nonlocal current_mode
-        if interaction.user.id != message.user.id:
-            await do_funny(interaction)
-            return
-        await interaction.response.defer()
+
+        await interaction.response.defer(ephemeral=True)
         current_mode = "Rewards"
         user = get_profile(message.guild.id, message.user.id)
         description = "**Rewards this season**\n"

--- a/main.py
+++ b/main.py
@@ -558,7 +558,7 @@ async def progress_embed(message, user, level_data, current_xp, old_xp, quest_da
         color=0x007F0E
     ).set_author(name=level_text).set_footer(text="/battlepass")
 
-    return await message.channel.send(embed=embed, ephemeral=True)
+    return await message.channel.send(embed=embed)
 
 
 # handle curious people clicking buttons


### PR DESCRIPTION
When many users are participating in the same channel, all of the publicly-visible responses create a lot of chatter/noise that many users find undesirable (this is especially true for the battlepass messages). These changes alter the battlepass responses so they are ephemeral (only visible to the calling user).