### PR TITLE
Trading UI - Value rounding

### DIFF
--- a/main.py
+++ b/main.py
@@ -3804,11 +3804,12 @@ async def trade(message: discord.Interaction, person_id: discord.User):
             if not valuestr:
                 valuestr = "Nothing offered!"
             else:
-                valuestr += f"*Total value: {round(valuenum):,}\nTotal cats: {round(total):,}*"
+                rounded = round(valuenum, 2)
+                valuestr += f"*Total value: {rounded:,}\nTotal cats: {total:,}*"
                 if number == 1:
-                    person1value = round(valuenum)
+                    person1value = rounded
                 else:
-                    person2value = round(valuenum)
+                    person2value = rounded
             personname = person.name.replace("_", "\\_")
             coolembed.add_field(name=f"{icon} {personname}", inline=True, value=valuestr)
 

--- a/main.py
+++ b/main.py
@@ -3790,8 +3790,11 @@ async def trade(message: discord.Interaction, person_id: discord.User):
             for k, v in persongives.items():
                 if k in prism_names:
                     valuestr += f"{get_emoji('prism')} {k}\n"
+                    prismvalue = 0
                     for v2 in type_dict.values():
-                        valuenum += round(len(CAT_TYPES) / v2)
+                        prismvalue += len(CAT_TYPES) / v2
+                        
+                    valuenum += round(prismvalue)
                     continue
                 if k == "rains":
                     valuestr += f"☔ {v:,}m of Cat Rains\n"

--- a/main.py
+++ b/main.py
@@ -3791,7 +3791,7 @@ async def trade(message: discord.Interaction, person_id: discord.User):
                 if k in prism_names:
                     valuestr += f"{get_emoji('prism')} {k}\n"
                     for v2 in type_dict.values():
-                        valuenum += len(CAT_TYPES) / v2
+                        valuenum += round(len(CAT_TYPES) / v2)
                     continue
                 if k == "rains":
                     valuestr += f"☔ {v:,}m of Cat Rains\n"
@@ -3805,7 +3805,7 @@ async def trade(message: discord.Interaction, person_id: discord.User):
                 valuestr = "Nothing offered!"
             else:
                 rounded = round(valuenum, 2)
-                valuestr += f"*Total value: {rounded:,}\nTotal cats: {total:,}*"
+                valuestr += f"*Total value: {rounded:,g}\nTotal cats: {total:,}*"
                 if number == 1:
                     person1value = rounded
                 else:


### PR DESCRIPTION
### Round values to 2 decimal places in trade UI

- This is due to singular low value cats presenting in a trade window for example
`1 x Fine = 4`,
`100 x Fine = 411`
The expected value would be 400, not 411.

Rounding to 2 decimal places for the most part alleviates this issue.

### Examples:
![image](https://github.com/user-attachments/assets/8e9c9a0c-6f1f-426b-b5d1-bc2257394077)

![image](https://github.com/user-attachments/assets/23439ce4-a08d-47bd-91eb-c802750fe4b7)

### Will not display decimals if whole numbers
![image](https://github.com/user-attachments/assets/35b50108-1e24-4ccf-b536-fb0c41e0ad07)




