### PR TITLE
incorrect battlepass timestamp

### DIFF
--- a/main.py
+++ b/main.py
@@ -3291,7 +3291,7 @@ async def battlepass(message: discord.Interaction):
         # catch
         catch_quest = battle["quests"]["catch"][user.catch_quest]
         if user.catch_cooldown != 0:
-            description += f"✅ ~~{catch_quest['title']}~~\n - Refreshes <t:{int(user.catch_cooldown + 12 * 3600)}:R>\n"
+            description += f"✅ ~~{catch_quest['title']}~~\n - Refreshes <t:{int(user.catch_cooldown + 12 * 3600 if user.catch_cooldown + 12 * 3600 > timestamp else timestamp)}:R>\n"
         else:
             progress = ""
             if catch_quest["progress"] != 1:
@@ -3308,7 +3308,7 @@ async def battlepass(message: discord.Interaction):
         # misc
         misc_quest = battle["quests"]["misc"][user.misc_quest]
         if user.misc_cooldown != 0:
-            description += f"✅ ~~{misc_quest['title']}~~\n - Refreshes <t:{int(user.misc_cooldown + 12 * 3600)}:R>\n\n"
+            description += f"✅ ~~{misc_quest['title']}~~\n - Refreshes <t:{int(user.misc_cooldown + 12 * 3600 if user.misc_cooldown + 12 * 3600 > timestamp else timestamp)}:R>\n\n"
         else:
             progress = ""
             if misc_quest["progress"] != 1:


### PR DESCRIPTION
handle the edge-case where nonvoting battlepass quest is set to refresh after season change so it's incorrect there is probably a there is probably a better way to write this (making more variables)