### PR TITLE
Remedy belated catches before caught response

### DIFF
--- a/main.py
+++ b/main.py
@@ -1904,7 +1904,13 @@ async def on_message(message: discord.Message):
                     # if some of the above explodes just give up
                     do_time = False
                     caught_time = "undefined amounts of time "
-
+                    
+                try:
+                    if time_caught >= 0:
+                        temp_belated_storage[message.channel.id] = {"time": time_caught, "users": [message.author.id]}
+                except Exception:
+                    pass
+                
                 if channel.cat_rains + 10 > time.time() or message.channel.id in temp_rains_storage:
                     do_time = False
 
@@ -2172,11 +2178,6 @@ async def on_message(message: discord.Message):
             finally:
                 user.save()
                 channel.save()
-                try:
-                    if time_caught >= 0:
-                        temp_belated_storage[message.channel.id] = {"time": time_caught, "users": [message.author.id]}
-                except Exception:
-                    pass
                 if decided_time:
                     await asyncio.sleep(decided_time)
                     try:


### PR DESCRIPTION
Belated battlepass frequently fails when the belated message is sent between the original catch and the catch response.
Moved setting of temp_belated_storage from after all catch processing to directly after time_caught is calculated in order to help remedy this.
Does _not_ contain fix for belated battlepass across maintenance loops.