### PR TITLE
fix: battlepass leaderboard is now sorted in descending order

### DIFF
--- a/main.py
+++ b/main.py
@@ -6043,7 +6043,7 @@ async def leaderboards(
             result = (
                 await Profile.filter(guild_id=message.guild.id, season=full_months_passed)
                 .annotate(final_value=Sum("battlepass"))
-                .order_by("-final_value", "progress")
+                .order_by("-final_value", "-progress")
                 .values("user_id", "final_value", "progress")
             )
         elif type == "Cookies":


### PR DESCRIPTION
The Battlepass Leaderboard sorts players with the same level in **ascending** order of the progress, placing those with the least progress at the top. Now, it uses **descending** order, showing players with the highest progress first.