### PR TITLE
Fix leaderboard off by one error (yes, really)

### DIFF
--- a/main.py
+++ b/main.py
@@ -6136,10 +6136,10 @@ async def leaderboards(
         messager_placement = 0
         for index, position in enumerate(result):
             if position["user_id"] == interaction.user.id:
-                interactor_placement = index
+                interactor_placement = index + 1
                 interactor = position["final_value"]
             if interaction.user != message.user and position["user_id"] == message.user.id:
-                messager_placement = index
+                messager_placement = index + 1
                 messager = position["final_value"]
 
         if type == "Slow":


### PR DESCRIPTION
Previously, being in 17th would result in the leaderboard showing you as being in 16th place. If you were in 16th place, the leaderboard would calculate you as being in 15th place and you would not show up at all. Placement was calculated as `index`, should be `index + 1`