### PR TITLE
Add rain overview after a cat rain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ catbot.db-wal
 data/
 app.py
 .vscode
+config.py
+images/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+config.py

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ catbot.db-wal
 data/
 app.py
 .vscode
-config.py
-images/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -137,4 +135,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-config.py

--- a/main.py
+++ b/main.py
@@ -1734,7 +1734,6 @@ async def on_message(message: discord.Message):
                         cat_cought_rain[channel.channel_id]["rare_catches"][channel.cattype].append(f"<@{user.user_id}>")
                 except Exception:
                     pass
-                    await message.channel.send(f"UH OH - {Exception}")
 
             if channel.yet_to_spawn < time.time():
                 # if there isnt already a scheduled spawn
@@ -3530,6 +3529,7 @@ async def actually_do_rain(message, channel):
     if 0 < channel.yet_to_spawn < time.time():
         await asyncio.sleep(random.uniform(channel.spawn_times_min, channel.spawn_times_max))
         await spawn_cat(str(message.channel.id))
+    # cat overview
     embed = discord.Embed(
         title="Rain overview",
         color=discord.Colour.from_str("#053BAF"),

--- a/main.py
+++ b/main.py
@@ -326,6 +326,9 @@ loop_count = 0
 # loops in dpy can randomly break, i check if is been over X minutes since last loop to restart it
 last_loop_time = 0
 
+# keep track of cat cought in rain
+cat_cought_rain = {}
+
 
 def get_emoji(name):
     global emojis
@@ -1721,6 +1724,17 @@ async def on_message(message: discord.Message):
             if channel.cat_rains > 0:
                 # we dont schedule next spawn during rains
                 decided_time = 0
+                try:
+                    if channel.cattype not in cat_cought_rain[channel.channel_id].keys():
+                        cat_cought_rain[channel.channel_id][channel.cattype] = 0
+                    cat_cought_rain[channel.channel_id][channel.cattype] += 1
+                    if type_dict[channel.cattype] < 40: # rare cats only
+                        if channel.cattype not in cat_cought_rain[channel.channel_id]["rare_catches"]:
+                            cat_cought_rain[channel.channel_id]["rare_catches"][channel.cattype] = []
+                        cat_cought_rain[channel.channel_id]["rare_catches"][channel.cattype].append(f"<@{user.user_id}>")
+                except Exception:
+                    pass
+                    await message.channel.send(f"UH OH - {Exception}")
 
             if channel.yet_to_spawn < time.time():
                 # if there isnt already a scheduled spawn
@@ -3483,6 +3497,7 @@ __Highlighted Stat__
 
 async def actually_do_rain(message, channel):
     first_spawn = True
+    cat_cought_rain[channel.channel_id] = {"rare_catches": {}}
     while channel.cat_rains > 0:
         if first_spawn:
             first_spawn = False
@@ -3515,6 +3530,24 @@ async def actually_do_rain(message, channel):
     if 0 < channel.yet_to_spawn < time.time():
         await asyncio.sleep(random.uniform(channel.spawn_times_min, channel.spawn_times_max))
         await spawn_cat(str(message.channel.id))
+    embed = discord.Embed(
+        title="Rain overview",
+        color=discord.Colour.from_str("#053BAF"),
+        description=""
+    )
+    for cat_type in cattypes:
+        if cat_type not in cat_cought_rain[channel.channel_id].keys() or cat_type == "rare_catches":
+            continue
+        if type_dict[cat_type] < 40:
+            list_cought = ""
+            for who_cought in cat_cought_rain[channel.channel_id]["rare_catches"][cat_type]:
+                list_cought += f" {who_cought}"
+            embed.description += f"{get_emoji(cat_type.lower() + 'cat')} {cat_type}:{list_cought}\n"
+            continue
+        embed.description += f"{get_emoji(cat_type.lower() + 'cat')} {cat_type}: **{cat_cought_rain[channel.channel_id][cat_type]}**\n"
+
+
+    await message.followup.send(embed=embed)
 
 
 @bot.tree.command(description="its raining cats")


### PR DESCRIPTION
adds a embed with the total amount of each types of cat caught during a rain, and for rarer cats (legendary and higher, or >1%), shows everyone who caught one of that type.
example after a rain (with rigged values):
<img width="356" height="427" alt="image" src="https://github.com/user-attachments/assets/85f6ec93-1138-463a-888f-14161156f08e" />
extreme example with further rigged values:
<img width="579" height="345" alt="image" src="https://github.com/user-attachments/assets/06579884-0e75-48d0-a478-0ded330537a7" />

feel free to roast my code, i havent done anything in python before
ive also never done a pull request so lmk if i did it wrong or smthin